### PR TITLE
Allows you to filter in ProeprtyGrid by simply typing "asset:{ASSETNA…

### DIFF
--- a/FrostyPlugin/Controls/FrostyPropertyGrid.cs
+++ b/FrostyPlugin/Controls/FrostyPropertyGrid.cs
@@ -713,6 +713,61 @@ namespace Frosty.Core.Controls
             return retVal;
         }
 
+        public bool FilterAsset(string asset, List<object> refObjects, bool doNotHideSubObjects = false)
+        {
+            if (_value is PointerRef pRef)
+            {
+                if (pRef.Type == PointerRefType.Internal)
+                {
+                    if (GetCustomAttribute<IsReferenceAttribute>() == null)
+                    {
+                        if (refObjects.Contains(pRef.Internal))
+                            return true;
+                        refObjects.Add(pRef.Internal);
+                    }
+                }
+            }
+
+            bool retVal = true;
+
+            foreach (var item in Children)
+            {
+                if (new List<string>() { "PropertyConnection", "EventConnection", "LinkConnection" }.Contains(item.Value.GetType().Name))
+                {
+                    item.IsHidden = true;
+                    foreach (PointerRef pr in new List<dynamic> { (PointerRef)((dynamic)item.Value).Source, (PointerRef)((dynamic)item.Value).Target })
+                    {
+                        if (pr.Type == PointerRefType.External)
+                        {
+                            if (App.AssetManager.GetEbxEntry(pr.External.FileGuid).Name == asset)
+                                item.IsHidden = false;
+                        }
+                    }
+                    if (retVal && !item.IsHidden)
+                        retVal = false;
+                }
+                else
+                {
+                    item.IsHidden = !doNotHideSubObjects;
+                    if (item.Value is PointerRef pr)
+                    {
+                        if (pr.Type == PointerRefType.External)
+                        {
+                            if (App.AssetManager.GetEbxEntry(pr.External.FileGuid) != null && App.AssetManager.GetEbxEntry(pr.External.FileGuid).Name == asset)
+                                item.IsHidden = false;
+                        }
+                    }
+                    if (!item.FilterAsset(asset, refObjects, !item.IsHidden) || !item.IsHidden)
+                        retVal = false;
+                }
+            }
+            if (!retVal)
+            {
+                IsHidden = false;
+            }
+            return retVal;
+        }
+
         public void AddChild(object value, object defValue)
         {
             IList list = (IList)_value;
@@ -1624,6 +1679,14 @@ namespace Frosty.Core.Controls
                     foreach (var item in items)
                     {
                         if (item.FilterGuid(guidValue.ToLower(), refObjects))
+                            item.IsHidden = true;
+                    }
+                }
+                else if (filterText.StartsWith("asset:") && App.AssetManager.GetEbxEntry(filterText.Substring(6)) != null)
+                {
+                    foreach (var item in items)
+                    {
+                        if (item.FilterAsset(filterText.Substring(6), refObjects))
                             item.IsHidden = true;
                     }
                 }


### PR DESCRIPTION
…ME}". The advantage of this being that it will pick up on every reference to a file, not just one of its GUIDs