### PR TITLE
Use build date instead of version number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -295,3 +295,5 @@ __pycache__/
 *.lib
 /FrostyEditor/MigrationBackup
 /Plugins/LevelEditorOldPlugin
+/FrostyEditor/BuildDate.txt
+/FrostyModManager/BuildDate.txt

--- a/FrostyEditor/App.xaml.cs
+++ b/FrostyEditor/App.xaml.cs
@@ -12,6 +12,7 @@ using Frosty.Core;
 using Frosty.Core.Controls;
 using FrostyCore;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace FrostyEditor
 {
@@ -63,7 +64,7 @@ namespace FrostyEditor
 #if FROSTY_DEVELOPER
             Version += " (SWBF2 Script Extender - Developer Mode)";
 #else
-            Version += $" (SWBF2 Script Extender v1.0.0)";
+            Version += $" (SWBF2 Script Extender {FrostyEditor.Properties.Resources.BuildDate.Trim().Split(' ').ElementAtOrDefault(1)})";
 #endif
         }
 

--- a/FrostyEditor/FrostyEditor.csproj
+++ b/FrostyEditor/FrostyEditor.csproj
@@ -299,6 +299,7 @@
     <Resource Include="Images\Noise.png" />
     <Resource Include="ChangeLog.txt" />
     <Resource Include="Credits.txt" />
+    <Resource Include="BuildDate.txt" />
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Images\Recent.png" />
@@ -399,8 +400,7 @@
     </PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PreBuildEvent>
-    </PreBuildEvent>
+    <PreBuildEvent>echo %25date%25 %25time%25 &gt; "$(ProjectDir)\BuildDate.txt"</PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/FrostyEditor/Properties/Resources.Designer.cs
+++ b/FrostyEditor/Properties/Resources.Designer.cs
@@ -59,5 +59,15 @@ namespace FrostyEditor.Properties {
                 resourceCulture = value;
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to 3-04-0-0 
+        ///.
+        /// </summary>
+        internal static string BuildDate {
+            get {
+                return ResourceManager.GetString("BuildDate", resourceCulture);
+            }
+        }
     }
 }

--- a/FrostyEditor/Properties/Resources.resx
+++ b/FrostyEditor/Properties/Resources.resx
@@ -118,4 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="BuildDate" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\BuildDate.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
 </root>

--- a/FrostyModManager/App.xaml.cs
+++ b/FrostyModManager/App.xaml.cs
@@ -10,6 +10,7 @@ using FrostySdk.IO;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Windows;
@@ -66,7 +67,7 @@ namespace FrostyModManager
 #if FROSTY_DEVELOPER
             Version += " (SWBF2 Script Extender - Developer Mode)";
 #else
-            Version += $" (SWBF2 Script Extender v1.0.0)";
+            Version += $" (SWBF2 Script Extender {FrostyModManager.Properties.Resources.BuildDate.Trim().Split(' ').ElementAtOrDefault(1)})";
 #endif
         }
 

--- a/FrostyModManager/FrostyModManager.csproj
+++ b/FrostyModManager/FrostyModManager.csproj
@@ -272,6 +272,7 @@
     <Resource Include="Images\RemoveMod.png" />
   </ItemGroup>
   <ItemGroup>
+    <Resource Include="BuildDate.txt" />
     <Resource Include="Credits.txt" />
     <Resource Include="Images\Frosty.png" />
     <Resource Include="Images\ModImportError.png" />
@@ -319,7 +320,6 @@
     </PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PreBuildEvent>
-    </PreBuildEvent>
+    <PreBuildEvent>echo %25date%25 %25time%25 &gt; "$(ProjectDir)\BuildDate.txt"</PreBuildEvent>
   </PropertyGroup>
 </Project>

--- a/FrostyModManager/Properties/Resources.Designer.cs
+++ b/FrostyModManager/Properties/Resources.Designer.cs
@@ -59,5 +59,15 @@ namespace FrostyModManager.Properties {
                 resourceCulture = value;
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to 3-04-0-0 
+        ///.
+        /// </summary>
+        internal static string BuildDate {
+            get {
+                return ResourceManager.GetString("BuildDate", resourceCulture);
+            }
+        }
     }
 }

--- a/FrostyModManager/Properties/Resources.resx
+++ b/FrostyModManager/Properties/Resources.resx
@@ -118,4 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="BuildDate" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\BuildDate.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
 </root>

--- a/FrostyModSupport/FrostyModExecutor.cs
+++ b/FrostyModSupport/FrostyModExecutor.cs
@@ -1726,7 +1726,7 @@ namespace Frosty.ModSupport
                 App.Logger.Log("Writing Manifest");
 
                 // finally copy in the left over patch data
-                CopyFileIfRequired(fs.BasePath + patchPath + "/initfs_win32", modDataPath + patchPath + "/initfs_win32");
+                CopyInitfsIfRequired(Path.Combine(fs.BasePath, patchPath, "initfs_win32"), Path.Combine(modDataPath, patchPath, "initfs_win32"));
 
                 if (ProfilesLibrary.DataVersion == (int)ProfileVersion.DragonAgeInquisition || ProfilesLibrary.DataVersion == (int)ProfileVersion.Battlefield4 || ProfilesLibrary.DataVersion == (int)ProfileVersion.NeedForSpeed || ProfilesLibrary.DataVersion == (int)ProfileVersion.PlantsVsZombiesGardenWarfare2 || ProfilesLibrary.DataVersion == (int)ProfileVersion.NeedForSpeedRivals)
                 {
@@ -1818,7 +1818,7 @@ namespace Frosty.ModSupport
                 {
                     // copy from old data to new data
                     CopyFileIfRequired(fs.BasePath + "Data/chunkmanifest", modDataPath + "Data/chunkmanifest");
-                    CopyFileIfRequired(fs.BasePath + "Data/initfs_Win32", modDataPath + "Data/initfs_Win32");
+                    CopyInitfsIfRequired(Path.Combine(fs.BasePath, "Data", "initfs_Win32"), Path.Combine(modDataPath, "Data", "initfs_Win32"));
                 }
 
                 // create the frosty mod list file
@@ -2350,6 +2350,18 @@ namespace Frosty.ModSupport
                 // copy file if it doesn't exist, or recently modified
                 if (!modFi.Exists || (modFi.Exists && baseFi.LastWriteTimeUtc > modFi.LastWriteTimeUtc || baseFi.Length != modFi.Length))
                     File.Copy(baseFi.FullName, modFi.FullName, true);
+            }
+        }
+
+        private void CopyInitfsIfRequired(string source, string dest)
+        {
+            FileInfo baseFi = new FileInfo(source);
+            FileInfo modFi = new FileInfo(dest);
+
+            // copy file if it doesn't exist
+            if (baseFi.Exists && !modFi.Exists)
+            {
+                File.Copy(baseFi.FullName, modFi.FullName, true);
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # FrostyToolsuite
 The most advanced modding platform for games running on DICE's Frostbite game engine.
-test
 
 ## Setup
 


### PR DESCRIPTION
also implements the builddate.txt better than how it was when it was in the main frosty repo, won't cause merge issues anymore.

fix for initfs copy to prevent it from being overwritten